### PR TITLE
fix block detection on slopes

### DIFF
--- a/src/main/java/net/pcal/highspeed/HighspeedService.java
+++ b/src/main/java/net/pcal/highspeed/HighspeedService.java
@@ -166,7 +166,7 @@ public class HighspeedService implements ModInitializer {
     // Private
 
     private PerBlockConfig getPerBlockConfig(AbstractMinecart minecart) {
-        return getPerBlockConfig(minecart, minecart.blockPosition());
+        return getPerBlockConfig(minecart, minecart.getCurrentBlockPosOrRailBelow());
     }
 
     private PerBlockConfig getPerBlockConfig(AbstractMinecart minecart, BlockPos minecartPos) {


### PR DESCRIPTION
Hi, I noticed when trying to use this mod that if the max speed for a certain block (like gravel) was set to be higher than the overall max speed that the minecart wouldn't be able to reach speed on an uphill/downhill section of the block, and my own testing reveals that changing the minecart position function fixes the issue.