### PR TITLE
chore: fix typo `1.24.3` -> `1.21.2`

### DIFF
--- a/src/main/resources/net/pcal/highspeed/default-config.json5
+++ b/src/main/resources/net/pcal/highspeed/default-config.json5
@@ -42,7 +42,7 @@
   /**
    * Setting this to true will force the new minecart physics to be enabled
    * for *all* worlds, even those that were created without the experimental
-   * 'Minecart Improvements' enabled.  As of Minecraft 1.24.3, the new physics
+   * 'Minecart Improvements' enabled.  As of Minecraft 1.21.2, the new physics
    * model is experimental and may result in unexpected behavior.
    *
    * The new physics model is vastly better than the old, and it's pretty


### PR DESCRIPTION
1.24.3 is not a minecraft version that exists
also, the minecart improvements experiment were added in 1.21.2: https://minecraft.wiki/w/Minecart_Improvements#History